### PR TITLE
Adding terminating semicolon at end of file

### DIFF
--- a/dist/pass-meter.js
+++ b/dist/pass-meter.js
@@ -173,4 +173,4 @@
   // Export to UMD
   return PassMeter
 
-}))
+}));

--- a/src/pass-meter.js
+++ b/src/pass-meter.js
@@ -166,4 +166,4 @@
   // Export to UMD
   return PassMeter
 
-}))
+}));


### PR DESCRIPTION
Due to a problem with our merge process, we had to add the trailing semicolon at end of the files. 
We use grunt to build a js file which includes all bower modules and self written js files. But without the trailing comma at the end of file, it causes error and the grunt process doesn't work. 
We therefore added a trailing semicolons. 
